### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/collinmutembei/nexus/security/code-scanning/1](https://github.com/collinmutembei/nexus/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the `test` job in the `.github/workflows/ci-cd.yml` file. Since the `test` job only needs to read the repository contents (to check out code and run tests), the minimal required permission is `contents: read`. This change should be made by adding the following block under the `test:` job definition, before the `runs-on:` line:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed, as this is a configuration change in the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
